### PR TITLE
[kubernetes-health]alert-KubePodNotReady

### DIFF
--- a/charts/kubernetes-operations/Chart.yaml
+++ b/charts/kubernetes-operations/Chart.yaml
@@ -3,7 +3,7 @@
 
 apiVersion: v2
 name: kubernetes-operations
-version: 1.2.7
+version: 1.2.8
 description: A set of Plutono dashboards and Prometheus alerting rules combined with playbooks to ensure effective operations of Kubernetes.
 maintainers:
   - name: richardtief

--- a/charts/kubernetes-operations/alerts/kubernetes-health.yaml
+++ b/charts/kubernetes-operations/alerts/kubernetes-health.yaml
@@ -121,9 +121,7 @@ groups:
        (max by (namespace, pod, node, phase) (kube_pod_status_ready{condition="false"}) 
          * on(pod) group_left(node) max by (node, pod) (kube_pod_info))
            * on(node) group_left()
-        kube_node_status_condition{condition="Ready",status="true"}
-           ==
-         1
+        kube_node_status_condition{condition="Ready",status="true"}==1
       )
     for: {{ dig "KubePodNotReady" "for" "30m" .Values.prometheusRules }}
     labels:

--- a/charts/kubernetes-operations/alerts/kubernetes-health.yaml
+++ b/charts/kubernetes-operations/alerts/kubernetes-health.yaml
@@ -108,13 +108,6 @@ groups:
     # alert on pods that are not ready but in the Running phase on a Ready node
     expr: |
       (
-        (max by (namespace, pod, node, phase) (kube_pod_status_phase{phase="Running"}) 
-          * on(pod) group_left(node) max by (node, pod) (kube_pod_info))
-            * on(pod, node, namespace)
-        (max by (namespace, pod, node, phase) (kube_pod_status_ready{condition="false"}) 
-          * on(pod) group_left(node) max by (node, pod) (kube_pod_info))
-            * on(node) group_left()
-     (
        (max by (namespace, pod, node, phase) (kube_pod_status_phase{phase="Running"}) 
          * on(pod) group_left(node) max by (node, pod) (kube_pod_info))
            * on(pod, node, namespace)

--- a/charts/kubernetes-operations/alerts/kubernetes-health.yaml
+++ b/charts/kubernetes-operations/alerts/kubernetes-health.yaml
@@ -114,7 +114,14 @@ groups:
         (max by (namespace, pod, node, phase) (kube_pod_status_ready{condition="false"}) 
           * on(pod) group_left(node) max by (node, pod) (kube_pod_info))
             * on(node) group_left()
-         sum by(node) (kube_node_status_condition{condition="Ready",status="true"})
+     (
+       (max by (namespace, pod, node, phase) (kube_pod_status_phase{phase="Running"}) 
+         * on(pod) group_left(node) max by (node, pod) (kube_pod_info))
+           * on(pod, node, namespace)
+       (max by (namespace, pod, node, phase) (kube_pod_status_ready{condition="false"}) 
+         * on(pod) group_left(node) max by (node, pod) (kube_pod_info))
+           * on(node) group_left()
+        kube_node_status_condition{condition="Ready",status="true"}
            ==
          1
       )

--- a/charts/kubernetes-operations/alerts/kubernetes-health.yaml
+++ b/charts/kubernetes-operations/alerts/kubernetes-health.yaml
@@ -114,7 +114,7 @@ groups:
         (max by (namespace, pod, node, phase) (kube_pod_status_ready{condition="false"}) 
           * on(pod) group_left(node) max by (node, pod) (kube_pod_info))
             * on(node) group_left()
-         sum by(node) (kube_node_status_condition{condition="Ready"})
+         sum by(node) (kube_node_status_condition{condition="Ready",status="true"})
            ==
          1
       )


### PR DESCRIPTION
add`status="true"` to filter the real "Ready" node for alert KubePodNotReady to improve the alert accuracy.

kube_node_status_condition{condition="Ready") has 3 status: `"unknown"`, `status:"false" `, `status="true"`

only when the. status="true" which indicate the node is in proper "Ready" status