### PR TITLE
chore: update alert KubeletManyRequestErrors

### DIFF
--- a/charts/kubernetes-operations/Chart.yaml
+++ b/charts/kubernetes-operations/Chart.yaml
@@ -3,7 +3,7 @@
 
 apiVersion: v2
 name: kubernetes-operations
-version: 1.2.9
+version: 1.2.10
 description: A set of Plutono dashboards and Prometheus alerting rules combined with playbooks to ensure effective operations of Kubernetes.
 maintainers:
   - name: richardtief

--- a/charts/kubernetes-operations/alerts/kubernetes-kubelet.yaml
+++ b/charts/kubernetes-operations/alerts/kubernetes-kubelet.yaml
@@ -88,7 +88,7 @@ groups:
       sum by (node) (
         rate(rest_client_requests_total{job="kubelet"}[5m])
         )
-      ) * 100> 1
+      ) > 0.01
     for: {{ dig "KubeletManyRequestErrors" "for" "5m" .Values.prometheusRules }}
     labels:
       severity: {{ dig "KubeletManyRequestErrors" "severity" "warning" .Values.prometheusRules }}

--- a/charts/kubernetes-operations/plugindefinition.yaml
+++ b/charts/kubernetes-operations/plugindefinition.yaml
@@ -9,7 +9,7 @@ kind: PluginDefinition
 metadata:
   name: kubernetes-operations
 spec:
-  version: 1.1.5
+  version: 1.1.6
   displayName: Kubernetes operations bundle
   description: Operations bundle for Kubernetes
   docMarkDownUrl: https://raw.githubusercontent.com/cloudoperators/kubernetes-operations/main/README.md
@@ -17,7 +17,7 @@ spec:
   helmChart:
     name: kubernetes-operations
     repository: oci://ghcr.io/cloudoperators/kubernetes-operations/charts
-    version: 1.2.9
+    version: 1.2.10
   options:
     - name: prometheusRules.create
       description: Create Prometheus rules


### PR DESCRIPTION
---
  **Fix KubeletManyRequestErrors alert expression and annotation formatting**

  Summary

  - Changed the alert threshold expression from * 100 > 1 to > 0.01 to keep the value as a ratio (0.0–1.0 scale)
  - This aligns with the humanizePercentage template function used in the annotation, which expects a ratio input and formats it as a human-readable percentage (e.g., 0.05 → 5%)

  Problem

  The original expression multiplied the error rate by 100 before comparing against > 1, producing a percentage value (e.g., 5.2). However, the annotation used humanizePercentage, which expects a ratio —
  this would have caused the displayed value to be 100x too large (e.g., showing 520% instead of 5.2%).