### PR TITLE
fix(alerts): exclude erofs/squashfs from KubernetesNodeReadOnlyRootFilesystem alert

### DIFF
--- a/charts/kubernetes-operations/Chart.yaml
+++ b/charts/kubernetes-operations/Chart.yaml
@@ -3,7 +3,7 @@
 
 apiVersion: v2
 name: kubernetes-operations
-version: 1.3.1
+version: 1.3.2
 description: A set of Perses dashboards and Prometheus alerting rules combined with playbooks to ensure effective operations of Kubernetes.
 maintainers:
   - name: richardtief

--- a/charts/kubernetes-operations/alerts/kubernetes-node.yaml
+++ b/charts/kubernetes-operations/alerts/kubernetes-node.yaml
@@ -131,7 +131,7 @@ groups:
 
 {{- if not (.Values.prometheusRules.disabled.KubernetesNodeReadOnlyRootFilesystem | default false) }}
   - alert: KubernetesNodeReadOnlyRootFilesystem
-    expr: sum by (node) (node_filesystem_readonly{mountpoint="/"}) > 0
+    expr: sum by (node) (node_filesystem_readonly{mountpoint="/", fstype!~"erofs|squashfs|iso9660"}) > 0
     for: {{ dig "KubernetesNodeReadOnlyRootFilesystem" "for" "15m" .Values.prometheusRules }}
     labels:
       severity: {{ dig "KubernetesNodeReadOnlyRootFilesystem" "severity" "warning" .Values.prometheusRules }}

--- a/charts/kubernetes-operations/plugindefinition.yaml
+++ b/charts/kubernetes-operations/plugindefinition.yaml
@@ -9,7 +9,7 @@ kind: PluginDefinition
 metadata:
   name: kubernetes-operations
 spec:
-  version: 1.2.1
+  version: 1.3.2
   displayName: Kubernetes operations bundle
   description: Operations bundle for Kubernetes
   docMarkDownUrl: https://raw.githubusercontent.com/cloudoperators/kubernetes-operations/main/README.md
@@ -17,7 +17,7 @@ spec:
   helmChart:
     name: kubernetes-operations
     repository: oci://ghcr.io/cloudoperators/kubernetes-operations/charts
-    version: 1.3.1
+    version: 1.3.2
   options:
     - name: prometheusRules.create
       description: Create Prometheus rules


### PR DESCRIPTION
## Description

during the recently KVM upgrade, we observed that the `KubernetesNodeReadOnlyRootFilesystem` alert fires false positives because `erofs` filesystems are read-only **by design** 

